### PR TITLE
mkFlake: do not export soon-to-be devoslib on each repo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,5 +57,8 @@
           in
             builtins.filterSource filter ./.;
         templates.mkflake.description = "template with necessary folders for mkFlake usage";
+      } // {
+        inherit lib;
       };
+
 }

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -30,11 +30,6 @@ let
     overlay = cfg.packages;
     inherit (cfg) overlays;
 
-    lib = import "${devos}/lib" {
-      inherit self nixos;
-      inputs = inputs // self.inputs;
-    };
-
     deploy.nodes = os.mkNodes deploy self.nixosConfigurations;
   };
 


### PR DESCRIPTION
It is not generally useful for everybody to export devos-lib.
We can reintroduce a lib-exportin interface, once we conceputualize
the private library sharing use case properly.

/cc @Pacman99 @nrdxp