### PR TITLE
lib: merge dev into lib

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,14 +1,10 @@
-args@{ nixos, self, ... }:
-let inherit (nixos) lib; in
-lib.makeExtensible (final:
-  let callLibs = file: import file
-    ({
-      inherit lib;
-
-      dev = final;
-    } // args);
+args@{ nixos, self, ... }: # TODO: craft well-defined api for devos-lib
+let
+  inherit (nixos) lib;
+in lib.makeExtensible (final:
+  let
+    callLibs = file: import file  ({ lib = final; } // args);
   in
-  with final;
   {
     inherit callLibs;
 
@@ -18,7 +14,8 @@ lib.makeExtensible (final:
     strings = callLibs ./strings.nix;
 
     mkFlake = callLibs ./mkFlake;
-
+  } //
+  with final; {
     inherit (attrs) mapFilterAttrs genAttrs' safeReadDir
       pathsToImportedAttrs concatAttrs filterPackages;
     inherit (lists) pathsIn;

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -1,4 +1,4 @@
-{ lib, nixos, dev, ... }:
+{ lib, ... }:
 {
   # pkgImport :: Nixpkgs -> Overlays -> System -> Pkgs
   pkgImport = nixpkgs: overlays: system:
@@ -9,22 +9,22 @@
 
   profileMap = map (profile: profile.default);
 
-  mkNodes = dev.callLibs ./mkNodes.nix;
+  mkNodes = lib.callLibs ./mkNodes.nix;
 
-  mkHosts = dev.callLibs ./mkHosts.nix;
+  mkHosts = lib.callLibs ./mkHosts.nix;
 
-  mkSuites = dev.callLibs ./mkSuites.nix;
+  mkSuites = lib.callLibs ./mkSuites.nix;
 
-  mkProfileAttrs = dev.callLibs ./mkProfileAttrs.nix;
+  mkProfileAttrs = lib.callLibs ./mkProfileAttrs.nix;
 
-  mkPkgs = dev.callLibs ./mkPkgs.nix;
+  mkPkgs = lib.callLibs ./mkPkgs.nix;
 
-  recImport = dev.callLibs ./recImport.nix;
+  recImport = lib.callLibs ./recImport.nix;
 
-  devosSystem = dev.callLibs ./devosSystem.nix;
+  devosSystem = lib.callLibs ./devosSystem.nix;
 
-  mkHomeConfigurations = dev.callLibs ./mkHomeConfigurations.nix;
+  mkHomeConfigurations = lib.callLibs ./mkHomeConfigurations.nix;
 
-  mkPackages = dev.callLibs ./mkPackages.nix;
+  mkPackages = lib.callLibs ./mkPackages.nix;
 }
 

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,4 +1,4 @@
-{ lib, dev, nixos, inputs, ... }:
+{ lib, nixos, inputs, ... }:
 
 { self, dir, extern, suites, overrides, multiPkgs, ... }:
 let
@@ -88,13 +88,13 @@ let
         };
       };
     in
-    dev.os.devosSystem {
+    lib.os.devosSystem {
       inherit specialArgs;
       system = defaultSystem;
       modules = modules // { inherit local lib; };
     };
 
-  hosts = dev.os.recImport
+  hosts = lib.os.recImport
     {
       inherit dir;
       _import = mkHostConfig;

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,10 +1,10 @@
-{ lib, dev, self, ... }:
+{ lib, self, ... }:
 
 { pkgs }:
 let
   inherit (self) overlay overlays;
   packagesNames = lib.attrNames (overlay null null)
-    ++ lib.attrNames (dev.concatAttrs
+    ++ lib.attrNames (lib.concatAttrs
     (lib.attrValues
       (lib.mapAttrs (_: v: v null null) overlays)
     )

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,27 +1,19 @@
-{ lib, dev, nixos, self, inputs, ... }:
+{ lib, nixos, self, inputs, ... }:
 
 { extern, overrides }:
 (inputs.utils.lib.eachDefaultSystem
   (system:
     let
-      overridePkgs = dev.os.pkgImport inputs.override [ ] system;
+      overridePkgs = lib.os.pkgImport inputs.override [ ] system;
       overridesOverlay = overrides.packages;
 
       overlays = [
-        (final: prev: {
-          lib = prev.lib.extend (lfinal: lprev: {
-            inherit dev;
-            inherit (lib) nixosSystem;
-
-            utils = inputs.utils.lib;
-          });
-        })
         (overridesOverlay overridePkgs)
         self.overlay
       ]
       ++ extern.overlays
       ++ (lib.attrValues self.overlays);
     in
-    { pkgs = dev.os.pkgImport nixos overlays system; }
+    { pkgs = lib.os.pkgImport nixos overlays system; }
   )
 ).pkgs

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -1,4 +1,4 @@
-{ lib, dev, ... }:
+{ lib, ... }:
 
 let mkProfileAttrs =
   /**
@@ -16,7 +16,7 @@ let mkProfileAttrs =
   let
     imports =
       let
-        files = dev.safeReadDir dir;
+        files = lib.safeReadDir dir;
 
         p = n: v:
           v == "directory"

--- a/lib/devos/mkSuites.nix
+++ b/lib/devos/mkSuites.nix
@@ -1,8 +1,7 @@
-{ lib, dev, ... }:
+{ lib, ... }:
 
 { users, profiles, userProfiles, suites } @ args:
 let
-  inherit (dev) os;
 
   definedSuites = suites {
     inherit (args) users profiles userProfiles;
@@ -16,7 +15,7 @@ let
     let defaults = lib.collect (x: x ? default) users;
     in map (x: x.default) defaults;
 
-  createSuites = _: suites: lib.mapAttrs (_: v: os.profileMap v) suites // {
+  createSuites = _: suites: lib.mapAttrs (_: v: lib.os.profileMap v) suites // {
     inherit allProfiles allUsers;
   };
 

--- a/lib/devos/recImport.nix
+++ b/lib/devos/recImport.nix
@@ -1,7 +1,7 @@
-{ lib, dev, ... }:
+{ lib,  ... }:
 
 { dir, _import ? base: import "${dir}/${base}.nix" }:
-dev.mapFilterAttrs
+lib.mapFilterAttrs
   (_: v: v != null)
   (n: v:
     if n != "default.nix" && lib.hasSuffix ".nix" n && v == "regular"
@@ -9,4 +9,4 @@ dev.mapFilterAttrs
       let name = lib.removeSuffix ".nix" n; in lib.nameValuePair (name) (_import name)
     else
       lib.nameValuePair ("") (null))
-  (dev.safeReadDir dir)
+  (lib.safeReadDir dir)

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,8 +1,8 @@
-{ lib, dev, ... }:
+{ lib, ... }:
 {
   pathsIn = dir:
     let
       fullPath = name: "${toString dir}/${name}";
     in
-    map fullPath (lib.attrNames (dev.safeReadDir dir));
+    map fullPath (lib.attrNames (lib.safeReadDir dir));
 }

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -1,8 +1,8 @@
-{ dev, inputs, ... }:
+{ lib, inputs, ... }:
 let
-  inherit (dev) os; # TODO: find a more approriate naming scheme
-  inherit (inputs) utils, deploy; # TODO: make this direct inputs of future devos-lib flake
-  evalFlakeArgs = dev.callLibs ./evalArgs.nix;
+  inherit (lib) os; # TODO: find a more approriate naming scheme
+  inherit (inputs) utils deploy; # TODO: make this direct inputs of future devos-lib flake
+  evalFlakeArgs = lib.callLibs ./evalArgs.nix;
 in
 
 { self, ... } @ args:

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,11 +1,9 @@
-{ self, dev, nixos, inputs, ... }:
+{ self, lib, inputs, ... }:
 
 { args }:
 let
-  argOpts = with nixos.lib; { config, options, ... }:
+  argOpts = with lib; { config, options, ... }:
     let
-      inherit (dev) os;
-
       inherit (config) self;
 
       inputAttrs = with types; functionTo attrs;
@@ -17,7 +15,7 @@ let
     {
       options = with types; {
         self = mkOption {
-          type = addCheck attrs nixos.lib.isStorePath;
+          type = addCheck attrs isStorePath;
           description = "The flake to create the devos outputs for";
         };
         hosts = mkOption {
@@ -48,7 +46,7 @@ let
         modules = mkOption {
           type = listOf moduleType;
           default = [];
-          apply = dev.pathsToImportedAttrs;
+          apply = pathsToImportedAttrs;
           description = ''
             list of modules to include in confgurations and export in 'nixosModules' output
           '';
@@ -56,7 +54,7 @@ let
         userModules = mkOption {
           type = listOf moduleType;
           default = [];
-          apply = dev.pathsToImportedAttrs;
+          apply = pathsToImportedAttrs;
           description = ''
             list of modules to include in home-manager configurations and export in
             'homeModules' output
@@ -130,7 +128,7 @@ let
           type = path;
           default = "${self}/overlays";
           defaultText = "\${self}/overlays";
-          apply = x: dev.pathsToImportedAttrs (dev.pathsIn (toString x));
+          apply = x: pathsToImportedAttrs (pathsIn (toString x));
           description = ''
             path to folder containing overlays which will be applied to pkgs and exported in
             the 'overlays' output
@@ -146,6 +144,6 @@ let
       };
     };
 in
-  nixos.lib.evalModules {
+  lib.evalModules {
     modules = [ argOpts args ];
   }


### PR DESCRIPTION
since lib is structured after upstream lib (lists, attrs, strings), and
it is even conceived as lib.makeExtensible, it does not appear
in line to namespace devos specific library additions: not only is the
name `dev` little self explaining, we also have the `os` namespace, for
if library functions are devos specific. The rest are just confenience
functions which might as well ladn upstream one day.

/cc @Pacman99 @nrdxp