### PR TITLE
ref: make onion with flake-utils

### DIFF
--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -12,8 +12,6 @@
           lib = prev.lib.extend (lfinal: lprev: {
             inherit lib;
             inherit (lib) nixosSystem;
-
-            utils = inputs.utils.lib;
           });
         })
         (overridesOverlay overridePkgs)

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -47,7 +47,7 @@
           pathsToImportedAttrs concatAttrs filterPackages;
         inherit (lists) pathsIn;
         inherit (strings) rgxToString;
-      });
+      } // utils.lib);
 
   in
 
@@ -57,7 +57,7 @@
     lib = {
       mkFlake = combinedLib.mkFlake;
       pkgs-lib = combinedLib.pkgs-lib;
-    };
+    } // utils.lib;
 
 
   }

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -1,4 +1,4 @@
-{ lib, utils, deploy, ... }:
+{ lib, deploy, ... }:
 let
   inherit (dev) os;
 in
@@ -31,7 +31,7 @@ let
     deploy.nodes = os.mkNodes deploy userFlakeSelf.nixosConfigurations;
   };
 
-  systemOutputs = utils.lib.eachDefaultSystem (system:
+  systemOutputs = lib.eachDefaultSystem (system:
     let
       pkgs = multiPkgs.${system};
       pkgs-lib = lib.pkgs-lib.${system};

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,4 +1,4 @@
-{ userFlakeSelf, lib, nixpkgs, utils, ... }:
+{ userFlakeSelf, lib, nixpkgs, ... }:
 
 { args }:
 let
@@ -190,7 +190,7 @@ let
         };
         supportedSystems = mkOption {
           type = listOf str;
-          default = utils.lib.defaultSystems;
+          default = lib.defaultSystems;
           description = ''
             The systems supported by this flake
           '';

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -1,5 +1,5 @@
-args@{ lib, utils, nixpkgs, ... }:
-lib.genAttrs utils.lib.defaultSystems (system:
+args@{ lib, nixpkgs, ... }:
+lib.genAttrs lib.defaultSystems (system:
   lib.makeExtensible (final:
     let
       pkgs = import nixpkgs { inherit system; };


### PR DESCRIPTION
We would switch that eventually to `fup`, so this only prepares the ground and flattens the different `lib` APIs passed all around even further (similar to previous `lib` + `dev` merge).