### PR TITLE
ref: reduce exposure to callLibs

### DIFF
--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 rec {
   # mapFilterAttrs ::
   #   (name -> value -> bool )

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   # pkgImport :: Nixpkgs -> Overlays -> System -> Pkgs
   pkgImport = nixpkgs: overlays: system:

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, userSelf, userFlakeInputs, ... }:
+{ lib, nixpkgs, userFlakeSelf, userFlakeInputs, ... }:
 
 { modules, ... } @ args:
 lib.nixosSystem (args // {
@@ -27,11 +27,11 @@ lib.nixosSystem (args // {
 
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
-                source = userSelf;
+                source = userFlakeSelf;
                 target = "/devos/";
               }];
               isoImage.storeContents = [
-                userSelf.devShell.${config.nixpkgs.system}
+                userFlakeSelf.devShell.${config.nixpkgs.system}
                 # include also closures that are "switched off" by the
                 # above profile filter on the local config attribute
                 fullHostConfig.system.build.toplevel

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, userSelf, inputs, ... }:
+{ lib, nixpkgs, userSelf, userFlakeInputs, ... }:
 
 { modules, ... } @ args:
 lib.nixosSystem (args // {
@@ -23,7 +23,7 @@ lib.nixosSystem (args // {
               disabledModules = map (x: [ x ])
                 (lib.remove modules.core suites.allProfiles);
 
-              nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
+              nix.registry = lib.mapAttrs (n: v: { flake = v; }) userFlakeInputs;
 
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{

--- a/lib/devos/mkHomeConfigurations.nix
+++ b/lib/devos/mkHomeConfigurations.nix
@@ -1,4 +1,4 @@
-{ lib, userSelf, ... }:
+{ lib, userFlakeSelf, ... }:
 
 with lib;
 let
@@ -6,7 +6,7 @@ let
     mapAttrs' (user: v: nameValuePair "${user}@${host}" v.home)
       config.config.system.build.homes;
 
-  hmConfigs = mapAttrs mkHomes userSelf.nixosConfigurations;
+  hmConfigs = mapAttrs mkHomes userFlakeSelf.nixosConfigurations;
 
 in
 foldl recursiveUpdate { } (attrValues hmConfigs)

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, userFlakeInputs, userSelf, ... }:
+{ lib, nixpkgs, userFlakeInputs, userFlakeSelf, ... }:
 
 { dir, extern, suites, overrides, multiPkgs, ... }:
 let
@@ -29,7 +29,7 @@ let
         useUserPackages = true;
 
         extraSpecialArgs = extern.userSpecialArgs // { suites = suites.user; };
-        sharedModules = extern.userModules ++ (builtins.attrValues userSelf.homeModules);
+        sharedModules = extern.userModules ++ (builtins.attrValues userFlakeSelf.homeModules);
       };
       users.mutableUsers = lib.mkDefault false;
 
@@ -37,14 +37,14 @@ let
 
       nix.nixPath = [
         "nixpkgs=${nixpkgs}"
-        "nixos-config=${userSelf}/compat/nixos"
+        "nixos-config=${userFlakeSelf}/compat/nixos"
         "home-manager=${userFlakeInputs.home}"
       ];
 
       nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
 
       nix.registry = {
-        devos.flake = userSelf;
+        devos.flake = userFlakeSelf;
         nixos.flake = nixpkgs;
         override.flake = userFlakeInputs.override;
       };
@@ -57,11 +57,11 @@ let
         }
       '';
 
-      system.configurationRevision = lib.mkIf (userSelf ? rev) userSelf.rev;
+      system.configurationRevision = lib.mkIf (userFlakeSelf ? rev) userFlakeSelf.rev;
     };
 
     # Everything in `./modules/list.nix`.
-    flakeModules = { imports = builtins.attrValues userSelf.nixosModules ++ extern.modules; };
+    flakeModules = { imports = builtins.attrValues userFlakeSelf.nixosModules ++ extern.modules; };
 
     cachix = ../../cachix.nix;
   };
@@ -78,7 +78,7 @@ let
         networking = { inherit hostName; };
 
         _module.args = {
-          self = userSelf;
+          self = userFlakeSelf;
           hosts = builtins.mapAttrs (_: host: host.config)
             (removeAttrs hosts [ hostName ]);
         };

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, inputs, userSelf, ... }:
+{ lib, nixpkgs, userFlakeInputs, userSelf, ... }:
 
 { dir, extern, suites, overrides, multiPkgs, ... }:
 let
@@ -38,7 +38,7 @@ let
       nix.nixPath = [
         "nixpkgs=${nixpkgs}"
         "nixos-config=${userSelf}/compat/nixos"
-        "home-manager=${inputs.home}"
+        "home-manager=${userFlakeInputs.home}"
       ];
 
       nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
@@ -46,7 +46,7 @@ let
       nix.registry = {
         devos.flake = userSelf;
         nixos.flake = nixpkgs;
-        override.flake = inputs.override;
+        override.flake = userFlakeInputs.override;
       };
 
       nix.package = pkgs.nixFlakes;

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,8 +1,8 @@
-{ lib, userSelf, ... }:
+{ lib, userFlakeSelf, ... }:
 
 { pkgs }:
 let
-  inherit (userSelf) overlay overlays;
+  inherit (userFlakeSelf) overlay overlays;
   packagesNames = lib.attrNames (overlay null null)
     ++ lib.attrNames (lib.concatAttrs
     (lib.attrValues

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,10 +1,10 @@
-{ lib, nixpkgs, userSelf, inputs, ... }:
+{ lib, nixpkgs, userSelf, utils, userFlakeInputs, ... }:
 
 { extern, overrides }:
-(inputs.utils.lib.eachDefaultSystem
+(utils.lib.eachDefaultSystem
   (system:
     let
-      overridePkgs = lib.os.pkgImport inputs.override [ ] system;
+      overridePkgs = lib.os.pkgImport userFlakeInputs.override [ ] system;
       overridesOverlay = overrides.packages;
 
       overlays = [

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -12,8 +12,6 @@
           lib = prev.lib.extend (lfinal: lprev: {
             inherit lib;
             inherit (lib) nixosSystem;
-
-            utils = inputs.utils.lib;
           });
         })
         (overridesOverlay overridePkgs)

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,4 +1,4 @@
-{ lib, nixpkgs, userSelf, utils, userFlakeInputs, ... }:
+{ lib, nixpkgs, userFlakeSelf, utils, userFlakeInputs, ... }:
 
 { extern, overrides }:
 (utils.lib.eachDefaultSystem
@@ -17,10 +17,10 @@
           });
         })
         (overridesOverlay overridePkgs)
-        userSelf.overlay
+        userFlakeSelf.overlay
       ]
       ++ extern.overlays
-      ++ (lib.attrValues userSelf.overlays);
+      ++ (lib.attrValues userFlakeSelf.overlays);
     in
     { pkgs = lib.os.pkgImport nixpkgs overlays system; }
   )

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -21,7 +21,7 @@
       let callLibs = file: import file
         ({
           lib = final;
-          inputs = inputs;
+          userFlakeInputs = {}; # TODO: Erm, this must become a proper argument to mkFlake
         } // inputs);
       in
       with final;

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -26,14 +26,15 @@
       in
       with final;
       let
-        attrs = callLibs ./attrs.nix;
-        lists = callLibs ./lists.nix;
-        strings = callLibs ./strings.nix;
+
+        attrs = import ./attrs.nix { lib = prev; };
+        lists = import ./lists.nix { lib = prev; };
+        strings = import ./strings.nix { lib = prev; };
       in
       {
         inherit callLibs;
 
-        os = callLibs ./devos;
+        os = import ./devos { lib = final; };
 
         mkFlake = {
           __functor = callLibs ./mkFlake;
@@ -41,7 +42,7 @@
           evalOldArgs = callLibs ./mkFlake/evalOldArgs.nix;
         };
 
-        pkgs-lib = callLibs ./pkgs-lib;
+        pkgs-lib = import ./pkgs-lib {lib = final; inherit nixpkgs deploy devshell};
 
         inherit (attrs) mapFilterAttrs genAttrs' safeReadDir
           pathsToImportedAttrs concatAttrs filterPackages;

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -47,7 +47,7 @@
           pathsToImportedAttrs concatAttrs filterPackages;
         inherit (lists) pathsIn;
         inherit (strings) rgxToString;
-      });
+      } // utils.lib);
 
   in
 
@@ -57,7 +57,7 @@
     lib = {
       mkFlake = combinedLib.mkFlake;
       pkgs-lib = combinedLib.pkgs-lib;
-    };
+    } // utils.lib;
 
 
   }

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   pathsIn = dir:
     let

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -1,4 +1,4 @@
-{ lib, utils, deploy, ... }:
+{ lib, deploy, ... }:
 let
   inherit (dev) os;
 in
@@ -31,7 +31,7 @@ let
     deploy.nodes = os.mkNodes deploy userFlakeSelf.nixosConfigurations;
   };
 
-  systemOutputs = utils.lib.eachDefaultSystem (system:
+  systemOutputs = lib.eachDefaultSystem (system:
     let
       pkgs = multiPkgs.${system};
       pkgs-lib = lib.pkgs-lib.${system};

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -1,7 +1,6 @@
-{ lib, inputs, ... }:
+{ lib, utils, deploy, ... }:
 let
   inherit (dev) os;
-  inherit (inputs) utils deploy;
 in
 
 _: { self, ... } @ args:

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -6,7 +6,7 @@ in
 _: { self, ... } @ args:
 let
 
-  userSelf = self;
+  userFlakeSelf = self;
 
   cfg = (lib.mkFlake.evalOldArgs { inherit args; }).config;
 
@@ -14,7 +14,7 @@ let
 
   outputs = {
     nixosConfigurations = os.mkHosts {
-      inherit userSelf multiPkgs;
+      inherit userFlakeSelf multiPkgs;
       inherit (cfg) extern suites overrides;
       dir = cfg.hosts;
     };
@@ -28,7 +28,7 @@ let
     overlay = cfg.packages;
     inherit (cfg) overlays;
 
-    deploy.nodes = os.mkNodes deploy userSelf.nixosConfigurations;
+    deploy.nodes = os.mkNodes deploy userFlakeSelf.nixosConfigurations;
   };
 
   systemOutputs = utils.lib.eachDefaultSystem (system:
@@ -40,9 +40,9 @@ let
     in
     {
       checks = pkgs-lib.tests.mkChecks {
-        inherit (userSelf.deploy) nodes;
-        hosts = userSelf.nixosConfigurations;
-        homes = userSelf.homeConfigurations;
+        inherit (userFlakeSelf.deploy) nodes;
+        hosts = userFlakeSelf.nixosConfigurations;
+        homes = userFlakeSelf.homeConfigurations;
       };
 
       inherit legacyPackages;

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,4 +1,4 @@
-{ userSelf, lib, nixpkgs, utils, ... }:
+{ userFlakeSelf, lib, nixpkgs, utils, ... }:
 
 { args }:
 let
@@ -161,8 +161,8 @@ let
           };
           profiles = mkOption {
             type = path;
-            default = "${userSelf}/profiles";
-            defaultText = "\${userSelf}/profiles";
+            default = "${userFlakeSelf}/profiles";
+            defaultText = "\${userFlakeSelf}/profiles";
             apply = x: os.mkProfileAttrs (toString x);
             description = "path to profiles folder that can be collected into suites";
           };

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,4 +1,4 @@
-{ userSelf, lib, inputs, utils, ... }:
+{ userSelf, lib, nixpkgs, utils, ... }:
 
 { args }:
 let
@@ -54,7 +54,7 @@ let
         options = with types; {
           input = mkOption {
             type = flakeType;
-            default = inputs.nixpkgs;
+            default = nixpkgs;
             description = ''
               nixpkgs flake input to use for this channel
            '';
@@ -199,7 +199,7 @@ let
           let
             default = {
               nixpkgs = {
-                input = inputs.nixpkgs;
+                input = nixpkgs;
               };
             };
           in

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,4 +1,4 @@
-{ userFlakeSelf, lib, nixpkgs, utils, ... }:
+{ userFlakeSelf, lib, nixpkgs, ... }:
 
 { args }:
 let
@@ -190,7 +190,7 @@ let
         };
         supportedSystems = mkOption {
           type = listOf str;
-          default = utils.lib.defaultSystems;
+          default = lib.defaultSystems;
           description = ''
             The systems supported by this flake
           '';

--- a/lib/mkFlake/evalOldArgs.nix
+++ b/lib/mkFlake/evalOldArgs.nix
@@ -1,4 +1,4 @@
-{ userSelf, lib, inputs, ... }:
+{ userFlakeSelf, lib, inputs, ... }:
 
 { args }:
 let
@@ -22,8 +22,8 @@ let
         };
         hosts = mkOption {
           type = path;
-          default = "${userSelf}/hosts";
-          defaultText = "\${userSelf}/hosts";
+          default = "${userFlakeSelf}/hosts";
+          defaultText = "\${userFlakeSelf}/hosts";
           apply = toString;
           description = ''
             Path to directory containing host configurations that will be exported
@@ -64,15 +64,15 @@ let
         };
         profiles = mkOption {
           type = path;
-          default = "${userSelf}/profiles";
-          defaultText = "\${userSelf}/profiles";
+          default = "${userFlakeSelf}/profiles";
+          defaultText = "\${userFlakeSelf}/profiles";
           apply = x: os.mkProfileAttrs (toString x);
           description = "path to profiles folder that can be collected into suites";
         };
         userProfiles = mkOption {
           type = path;
-          default = "${userSelf}/users/profiles";
-          defaultText = "\${userSelf}/users/profiles";
+          default = "${userFlakeSelf}/users/profiles";
+          defaultText = "\${userFlakeSelf}/users/profiles";
           apply = x: os.mkProfileAttrs (toString x);
           description = "path to user profiles folder that can be collected into userSuites";
         };
@@ -97,8 +97,8 @@ let
           };
         users = mkOption {
           type = path;
-          default = "${userSelf}/users";
-          defaultText = "\${userSelf}/users";
+          default = "${userFlakeSelf}/users";
+          defaultText = "\${userFlakeSelf}/users";
           apply = x: os.mkProfileAttrs (toString x);
           description = ''
             path to folder containing profiles that define system users
@@ -121,9 +121,9 @@ let
               { modules = []; overlays = []; specialArgs = []; userModules = []; userSpecialArgs = []; }
             '';
             # So unneeded extern attributes can safely be deleted
-            apply = x: defaults // (x { inputs = inputs // userSelf.inputs; });
+            apply = x: defaults // (x { inputs = inputs // userFlakeSelf.inputs; });
             description = ''
-              Function with argument 'inputs' that contains all devos and ''${userSelf}'s inputs.
+              Function with argument 'inputs' that contains all devos and ''${userFlakeSelf}'s inputs.
               The function should return an attribute set with modules, overlays, and
               specialArgs to be included across nixos and home manager configurations.
               Only attributes that are used should be returned.
@@ -131,8 +131,8 @@ let
           };
         overlays = mkOption {
           type = path;
-          default = "${userSelf}/overlays";
-          defaultText = "\${userSelf}/overlays";
+          default = "${userFlakeSelf}/overlays";
+          defaultText = "\${userFlakeSelf}/overlays";
           apply = x: lib.pathsToImportedAttrs (lib.pathsIn (toString x));
           description = ''
             path to folder containing overlays which will be applied to pkgs and exported in

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -1,4 +1,4 @@
-args@{ lib, nixpkgs, ... }:
+args@{ lib, nixpkgs, deploy, devshell }:
 lib.genAttrs lib.defaultSystems (system:
   lib.makeExtensible (final:
     let

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -1,5 +1,5 @@
-args@{ lib, utils, nixpkgs, ... }:
-lib.genAttrs utils.lib.defaultSystems (system:
+args@{ lib, nixpkgs, ... }:
+lib.genAttrs lib.defaultSystems (system:
   lib.makeExtensible (final:
     let
       pkgs = import nixpkgs { inherit system; };

--- a/lib/pkgs-lib/shell/default.nix
+++ b/lib/pkgs-lib/shell/default.nix
@@ -1,10 +1,10 @@
-{ lib, inputs, system, nixpkgs, ... }:
+{ lib, devshell, deploy, system, nixpkgs, ... }:
 let
   overlays = [
-    inputs.devshell.overlay
+    devshell.overlay
     (final: prev: {
       deploy-rs =
-        inputs.deploy.packages.${prev.system}.deploy-rs;
+        deploy.packages.${prev.system}.deploy-rs;
     })
   ];
 

--- a/lib/pkgs-lib/tests/default.nix
+++ b/lib/pkgs-lib/tests/default.nix
@@ -1,11 +1,11 @@
-{ pkgs, system, inputs, nixpkgs, lib, ... }:
+{ pkgs, system, deploy, nixpkgs, lib, ... }:
 let
   mkChecks = { hosts, nodes, homes ? { } }:
     let
       deployHosts = lib.filterAttrs
         (n: _: hosts.${n}.config.nixpkgs.system == system)
         nodes;
-      deployChecks = inputs.deploy.lib.${system}.deployChecks { nodes = deployHosts; };
+      deployChecks = deploy.lib.${system}.deployChecks { nodes = deployHosts; };
       tests =
         lib.optionalAttrs (deployHosts != { }) {
           profilesTest = profilesTest (hosts.${(builtins.head (builtins.attrNames deployHosts))});

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   # returns matching part of _regex_ _string_; null indicates failure.
   rgxToString = regex: string:


### PR DESCRIPTION
for clarity's sake, expose which function uses final and prev, so that
people can have a clearer understanding how they relate to each other
in terms of dependencies.

also a simple `{ lib = final; }` probably does not warrant a complete
callLibs obscurization.